### PR TITLE
fix: add support for module exceptions, clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ module.exports.transform = function ({
       ["metro-plugin-anisotropic-transform"]: {
         cyclicDependents: /.+\/node_modules\/expo\/AppEntry\.js$/,
         globalScopeFilter: {
-          'react-native-animated-charts': {},
+          'react-native-animated-charts': {
+            exceptions: ['my-package'], // optional
+          },
         },
       },
     },

--- a/index.js
+++ b/index.js
@@ -139,11 +139,24 @@ module.exports.transform = async function anisotropicTransform(src, filename, op
             allowedGlobalScope.indexOf(maybeDisallowedGlobalScope) < 0,
         );
         if (disallowedGlobalScope.length) {
-          resolve({
-            type: TYPE_GLOBAL_SCOPE_FILTER,
-            referrer: file,
-            globalScope: disallowedGlobalScope,
-          });
+          const packageInError = getPackageNameByFilePath(nodeModulesDir, file)
+          const actuallyDisallowedGlobalScope = []
+
+          for (const disallowed of disallowedGlobalScope) {
+            const disallowedPackage = getPackageNameByFilePath(nodeModulesDir, disallowed);
+            const allowedPackages = globalScopeFilter[disallowedPackage]?.exceptions || [];
+            if (!allowedPackages.includes(packageInError)) {
+              actuallyDisallowedGlobalScope.push(disallowed);
+            }
+          }
+
+          if (actuallyDisallowedGlobalScope.length) {
+            resolve({
+              type: TYPE_GLOBAL_SCOPE_FILTER,
+              referrer: file,
+              globalScope: actuallyDisallowedGlobalScope,
+            });
+          }
         }
       }
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const { name } = require("./package.json");
 const { version } = require("react-native/package.json");
 const reactNativeMinorVersion = minor(version);
 
-const getUpstreamTransformer = () => {
+const upstreamTransformer = (() => {
   if (reactNativeMinorVersion >= 59) {
     return require("metro-react-native-babel-transformer");
   } else if (reactNativeMinorVersion >= 56) {
@@ -28,7 +28,7 @@ const getUpstreamTransformer = () => {
       oldUpstreamTransformer.transform(src, filename, options),
     };
   }
-};
+})();
 
 // basically is a node_module
 function isNodeModule(parent, dir) {
@@ -173,5 +173,5 @@ module.exports.transform = async function anisotropicTransform(src, filename, op
     });
   }
 
-  return getUpstreamTransformer().transform({ src, filename, options });
+  return upstreamTransformer.transform({ src, filename, options });
 };


### PR DESCRIPTION
Best to review this commit-by-commit.

It adds support for an `exceptions` array on each global scope filter object so that we can selectively allow packages to import restricted packages. Example:

```
...
        globalScopeFilter: {
          'react-native-animated-charts': {
            exceptions: ['my-package'], // optional
          },
        },
...
```

For the rest, all I did was find/replace with some naming updates that I think make things much clearer (I spent a lot of time double checking how all this works), move a couple things around for consistency, and format with prettier.

To test, check out my [Ratio branch](https://github.com/rainbow-me/rainbow/pull/4563) and install this branch in the repo like `rainbow-me/metro-plugin-anisotropic-transform#dev`. Then try a build, it should work. Remove the `exceptions` array from `metro.transform.js` and try again, it should fail.