### PR TITLE
RN 0.73+: use @react-native/metro-babel-transformer

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ const defaultOptions = {
 const upstreamTransformer = (() => {
   const RN_MINOR_VERSION = minor(RN_VERSION);
 
-  if (RN_MINOR_VERSION >= 59) {
+  if (RN_MINOR_VERSION >= 73) {
+    return require("@react-native/metro-babel-transformer");
+  } else if (RN_MINOR_VERSION >= 59) {
     return require("metro-react-native-babel-transformer");
   } else if (RN_MINOR_VERSION >= 56) {
     return require("metro/src/reactNativeTransformer");


### PR DESCRIPTION
As of RN 0.73, `metro-react-native-babel-transformer` became `@react-native/metro-babel-transformer`: https://reactnative.dev/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#babel-package-renames